### PR TITLE
Serve custom stylesheets for chainlit with flask

### DIFF
--- a/docs/configs.md
+++ b/docs/configs.md
@@ -21,6 +21,7 @@ USE_KEY_STORAGE | Use NER keys for Chroma metadata
 COLLECTION | Chroma collection to use. "" to disable Chroma
 EMBEDDINGS_TYPE | llama/spacy/hugginface
 EMBEDDINGS_model | spacy/hugginface model name (needs to be installed)
+CUSTOM_CSS | Url to the custom css file to be used by the application.
 VECTOR_K | Fetch k closest embeddings for mmr
 BUFFER_K | Buffer last k exchanges to conversation context
 FETCH_K | Fetch k closest embeddings for similiarity

--- a/docs/running_the_chatbot.md
+++ b/docs/running_the_chatbot.md
@@ -8,9 +8,18 @@ If you call chainlit directly, the character name and avatar picture won't updat
 Note: Currently something seems to be cached by chainlit. Until I find a way to clear the cache,
 you need to call run_chat twice for changes to take effect.
 
+Some browsers don't allow loading css file from local directories. For testing purposes there is a flask script to run a simple http server that serves stylesheets from the "static/" directory. You will need to run the flask server in another terminal instance.
+
 ```
 cd src\llama_cpp_langchain_chat
 python -m run_chat
 ```
 
 The chatbot should open in your browser<BR>
+
+Running flask
+```
+hatch shell chat
+cd .\src\llama_cpp_chat_memory\
+flask --app flask_web_server run
+```

--- a/docs/running_the_env.md
+++ b/docs/running_the_env.md
@@ -1,9 +1,16 @@
 ### Running the env
-You'll need to run all the commands inside the virtual env.
+You'll need to run all the commands inside the virtual env. Some browsers don't allow loading css file from local directories. For testing purposes there is a flask script to run a simple http server that serves stylesheets from the "static/" directory. You will need to run the flask server in another terminal instance.
 ```
 hatch shell chat
 (optional for cuda support)$env:FORCE_CMAKE=1
 (optional for cuda support)$env:CMAKE_ARGS="-DLLAMA_CUBLAS=on"
 (optional for cuda support)pip install llama-cpp-python==VERSION --force-reinstall --upgrade --no-cache-dir --no-deps
 cd src\llama_cpp_langchain_chat
+```
+
+Running flask
+```
+hatch shell chat
+cd .\src\llama_cpp_chat_memory\
+flask --app flask_web_server run
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
 "pandas==2.2.2",
 "pyarrow==16.0.0",
 "trafilatura==1.8.1",
+"flask==3.0.3",
 ]
 
 [project.urls]

--- a/src/llama_cpp_chat_memory/.env.example
+++ b/src/llama_cpp_chat_memory/.env.example
@@ -12,6 +12,7 @@ USE_KEY_STORAGE = True
 COLLECTION = "skynet"
 EMBEDDINGS_TYPE = "spacy"
 EMBEDDINGS_MODEL = "en_core_web_lg"
+CUSTOM_CSS="http://127.0.0.1:5000/static/style.css"
 VECTOR_K = 1
 BUFFER_K = 3
 FETCH_K = 10

--- a/src/llama_cpp_chat_memory/flask_web_server.py
+++ b/src/llama_cpp_chat_memory/flask_web_server.py
@@ -1,0 +1,18 @@
+from flask import Flask, send_from_directory
+
+app = Flask(__name__)
+
+
+@app.route("/")
+def hello_world():
+    return "<p>Hello, World!</p>"
+
+
+@app.route("/test/")
+def test():
+    return "<p>TEST!</p>"
+
+
+@app.route("/static/<path:path>")
+def send_style(path):
+    return send_from_directory("static", path)

--- a/src/llama_cpp_chat_memory/run_chat.py
+++ b/src/llama_cpp_chat_memory/run_chat.py
@@ -17,6 +17,7 @@ def update_toml():
     prompt_dir = getenv("CHARACTER_CARD_DIR")
     prompt_name = getenv("CHARACTER_CARD")
     prompt_source = join(prompt_dir, prompt_name)
+    custom_css = getenv("CUSTOM_CSS")
 
     extension = splitext(prompt_source)[1]
     match extension:
@@ -51,6 +52,9 @@ def update_toml():
     with open(config_toml_path, encoding="utf-8") as toml_file:
         toml_dict = toml.load(toml_file)
         toml_dict["UI"]["name"] = char_name
+
+    if custom_css != "" or None:
+        toml_dict["UI"]["custom_css"] = custom_css
 
     with open(file=config_toml_path, mode="w", encoding="utf-8") as toml_file:
         toml.dump(toml_dict, toml_file)

--- a/src/llama_cpp_chat_memory/static/style.css
+++ b/src/llama_cpp_chat_memory/static/style.css
@@ -1,0 +1,12 @@
+/*
+Sets the chatbot avatar image size to 240px * 240 px
+*/
+div.css-nztacq {
+    width: 240px;
+    height: 240px;
+}
+
+img.css-1hy9t21 {
+    width: 240px;
+    height: 240px;
+}


### PR DESCRIPTION
- Added configs for custom styles
- Added an example stylesheet
- Added a flask app to serve stylesheets